### PR TITLE
Changed link to Angular snippets to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Prettier settings
 
 Here is the list of extensions the pack includes:
 
-[Angular v4 Snippets](https://marketplace.visualstudio.com/items?itemName=johnpapa.Angular2) - Angular snippets that follow the official style guide, for TypeScript, templates, and RxJS.
+[Angular v5 Snippets](https://marketplace.visualstudio.com/items?itemName=johnpapa.Angular2) - Angular snippets that follow the official style guide, for TypeScript, templates, and RxJS.
 
 [Angular Language Service](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template) - This extension provides a rich editing experience for Angular templates, both inline and external templates. This extension is brought to you by members of the Angular team. It is fantastic at helping write solid code in the html templates.
 


### PR DESCRIPTION
The snippet pack was pointing to snippet pack for Angular 5 but link text was still Angular 4