### PR TITLE
feat: add Angular Schematics extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,5 @@ Here is the list of extensions the pack includes:
 [Material Icon Theme](https://marketplace.visualstudio.com/items?itemName=pkief.material-icon-theme) Show material icons in the explorer
 
 [Node npm](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script) This extension supports running npm scripts defined in the package.json file and validating the installed modules against the dependencies defined in the package.json.
+
+[Angular Schematics](https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics) This extension allows you to launch Angular schematics (CLI commands) from files Explorer (right-click) or Command Palette.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "johnpapa.winteriscoming",
         "esbenp.prettier-vscode",
         "eg2.vscode-npm-script",
-        "pkief.material-icon-theme"
+        "pkief.material-icon-theme",
+        "cyrilletuzi.angular-schematics"
     ]
 }


### PR DESCRIPTION
Hi @johnpapa,

I did a GUI tool for Angular schematics / CLI commands for VS Code. It was done to improve productivity, so I think it would really fit in this Angular extension pack.

You can test the extension here: [https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics](https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics)

If you think it's a good extension, this PR adds it to your extension pack. Otherwise, I would appreciate feedback. Thanks.