### PR TITLE
Update for VS Code 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ Here is the list of extensions the pack includes:
 
 [Chrome Debugger](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) - VS Code debugger for Chrome.
 
-[Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense) - Visual Studio Code plugin that autocompletes filenames. Hopefully, VS Code will bake this in at some point. Until then, this is a keeper.
-
 [Angular Inline](https://marketplace.visualstudio.com/items?itemName=natewallace.angular2-inline) - Visual Studio Code language extension for javascript/typescript files that use Angular2.
 
 [Winter is Coming](https://marketplace.visualstudio.com/items?itemName=johnpapa.winteriscoming) theme

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "EditorConfig.EditorConfig",
         "eg2.tslint",
         "msjsdiag.debugger-for-chrome",
-        "christian-kohler.path-intellisense",
         "natewallace.angular2-inline",
         "johnpapa.winteriscoming",
         "esbenp.prettier-vscode",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "categories": [
         "Extension Packs"
     ],
-    "extensionDependencies": [
+    "extensionPack": [
         "johnpapa.Angular2",
         "Angular.ng-template",
         "EditorConfig.EditorConfig",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "version": "0.4.0",
     "publisher": "johnpapa",
     "engines": {
-        "vscode": "^1.12.0"
+        "vscode": "^1.26.0"
     },
     "categories": [
         "Extension Packs"


### PR DESCRIPTION
Use `extensionPack` instead of `extensionDependencies` in `package.json`.

As per the VS Code 1.26 release notes "[t]his will make it much simpler and easier for users to manage an Extension Pack and its bundled extensions. It allows deactivating and uninstalling extensions installed by the extension pack without affecting the extension pack itself."

"An Extension Pack should not have any functional dependencies with its bundled extensions and they should be manageable independent of the pack." "This needs adoption by Extension Packs":

- https://code.visualstudio.com/updates/v1_26#_extension-packs-revisited
- https://code.visualstudio.com/updates/v1_26#_extension-pack-management

Since I don't have any experience in developing VS Code extensions I wasn't able to successfully test this on my machine. Pressing `F5` as described in the `vsc-extension-quickstart.md` worked but didn't show the expected results.

The `extensionPack` feature had been discussed in https://github.com/Microsoft/vscode/issues/48430

Can anyone please confirm this is working? What about downwards compatibility?

Resolves #10 