### PR TITLE
chore: remove obsolete npm package 'path-intellisense'

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,6 @@ Here is the list of extensions the pack includes:
 
 [Chrome Debugger](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) - VS Code debugger for Chrome.
 
-[Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense) - Visual Studio Code plugin that autocompletes filenames. Hopefully, VS Code will bake this in at some point. Until then, this is a keeper.
-
 [Angular Inline](https://marketplace.visualstudio.com/items?itemName=natewallace.angular2-inline) - Visual Studio Code language extension for javascript/typescript files that use Angular2.
 
 [Winter is Coming](https://marketplace.visualstudio.com/items?itemName=johnpapa.winteriscoming) theme

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "EditorConfig.EditorConfig",
         "eg2.tslint",
         "msjsdiag.debugger-for-chrome",
-        "christian-kohler.path-intellisense",
         "natewallace.angular2-inline",
         "johnpapa.winteriscoming",
         "esbenp.prettier-vscode",


### PR DESCRIPTION
VS Code already provides IntelliSense for paths.

![image](https://user-images.githubusercontent.com/15670613/44837923-32323800-ac3b-11e8-8874-ddbd12eb592b.png)

