### PR TITLE
Could karma-problem-matcher be added?

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,5 @@ Here is the list of extensions the pack includes:
 [Material Icon Theme](https://marketplace.visualstudio.com/items?itemName=pkief.material-icon-theme) Show material icons in the explorer
 
 [Node npm](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script) This extension supports running npm scripts defined in the package.json file and validating the installed modules against the dependencies defined in the package.json.
+
+[Karma Problem Matcher](https://marketplace.visualstudio.com/items?itemName=rctay.karma-problem-matcher) Capture errors from Karma tests running in Visual Studio Code, so test failures will show up in 'Problems' pane (Ctrl+Shift+M on Windows/Linux, ⇧⌘M on Mac) and the failing test can also be made known to VS Code, eg. highlighted with squiggly lines, jumping to it with F8.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "johnpapa.winteriscoming",
         "esbenp.prettier-vscode",
         "eg2.vscode-npm-script",
-        "pkief.material-icon-theme"
+        "pkief.material-icon-theme",
+        "rctay.karma-problem-matcher"
     ]
 }


### PR DESCRIPTION
The extension defines a problemMatcher to capture errors from Karma tests, so test failures will be made known to VS Code.