### PR TITLE
feature(tslint) change to new tslint extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "johnpapa.Angular2",
         "Angular.ng-template",
         "EditorConfig.EditorConfig",
-        "eg2.tslint",
+        "ms-vscode.vscode-typescript-tslint-plugin",
         "msjsdiag.debugger-for-chrome",
         "christian-kohler.path-intellisense",
         "natewallace.angular2-inline",


### PR DESCRIPTION
This will change the dependency from `eg.tslint` to 'ms-vscode.vscode-typescript-tslint-plugin'

Closes #22 