### PR TITLE
remove vscode-npm-script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,8 +16,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint",
-		"esbenp.prettier-vscode",
-		"eg2.vscode-npm-script"
+		"esbenp.prettier-vscode"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "johnpapa.winteriscoming",
     "johnpapa.vscode-peacock",
     "esbenp.prettier-vscode",
-    "eg2.vscode-npm-script",
     "pkief.material-icon-theme"
   ]
 }


### PR DESCRIPTION
## Purpose
- Deprecation

## What
`vscode-npm-script` is removed from this extension pack because it is deprecated.
https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script

Closes #46
